### PR TITLE
Fix argument list too long

### DIFF
--- a/tests/test_surface_area_change.py
+++ b/tests/test_surface_area_change.py
@@ -57,7 +57,7 @@ def test_generate_tasks_cli_backlog_processing(
 
     assert result.exit_code == 0
 
-    bash_command = "cat /tmp/tasks | jq '.[0]'"
+    bash_command = "cat /tmp/tasks_chunks | jq '.[0]'"
     task_list_str = subprocess.check_output(bash_command, shell=True, universal_newlines=True)
     task_list = json.loads(task_list_str)
 

--- a/waterbodies/cli/surface_area_change/generate_tasks.py
+++ b/waterbodies/cli/surface_area_change/generate_tasks.py
@@ -142,11 +142,12 @@ def generate_tasks(
     task_chunks = [chunk.tolist() for chunk in task_chunks]
     task_chunks = list(filter(None, task_chunks))
     task_chunks_count = str(len(task_chunks))
+    _log.info(f"{len(sorted_tasks)} tasks chunked into {task_chunks_count} chunks")
     task_chunks_json_array = json.dumps(task_chunks)
 
     tasks_directory = "/tmp/"
-    tasks_output_file = os.path.join(tasks_directory, "tasks")
-    tasks_count_file = os.path.join(tasks_directory, "tasks_count")
+    tasks_output_file = os.path.join(tasks_directory, "tasks_chunks")
+    tasks_count_file = os.path.join(tasks_directory, "tasks_chunks_count")
 
     fs = get_filesystem(path=tasks_directory)
 
@@ -156,8 +157,8 @@ def generate_tasks(
 
     with fs.open(tasks_output_file, "w") as file:
         file.write(task_chunks_json_array)
-    _log.info(f"Tasks written to {tasks_output_file}")
+    _log.info(f"Tasks chunks written to {tasks_output_file}")
 
     with fs.open(tasks_count_file, "w") as file:
         file.write(task_chunks_count)
-    _log.info(f"Tasks count written to {tasks_count_file}")
+    _log.info(f"Tasks chunks count written to {tasks_count_file}")

--- a/waterbodies/cli/surface_area_change/process_task.py
+++ b/waterbodies/cli/surface_area_change/process_task.py
@@ -33,7 +33,11 @@ from waterbodies.text import get_task_id_str_from_tuple
         case_sensitive=True,
     ),
 )
-@click.option("--task-list", type=str, help="List of tasks to process")
+@click.option(
+    "--tasks-list-file",
+    type=str,
+    help="Path to the text file containing the list of tasks to process.",
+)
 @click.option(
     "--historical-extent-rasters-directory",
     type=str,
@@ -50,7 +54,7 @@ from waterbodies.text import get_task_id_str_from_tuple
 def process_tasks(
     verbose,
     run_type,
-    task_list,
+    tasks_list_file,
     historical_extent_rasters_directory,
     overwrite,
 ):
@@ -67,7 +71,11 @@ def process_tasks(
 
     engine = get_waterbodies_engine()
 
-    tasks = json.loads(task_list)
+    fs = get_filesystem(path=tasks_list_file)
+    with fs.open(tasks_list_file) as file:
+        content = file.read()
+        decoded_content = content.decode()
+        tasks = json.loads(decoded_content)
 
     failed_tasks = []
     for idx, task in enumerate(tasks):


### PR DESCRIPTION
- Replace the `task-list` parameter in `process-tasks` with `tasks-list-file`